### PR TITLE
Additional Architectures

### DIFF
--- a/pyngrok/installer.py
+++ b/pyngrok/installer.py
@@ -65,13 +65,14 @@ def install_ngrok(ngrok_path):
     if not os.path.exists(ngrok_dir):
         os.mkdir(ngrok_dir)
 
+    arch = 'x86_64' if sys.maxsize > 2 ** 32 else 'i386'
+    if 'arm' in os.uname()[4]:
+        arch += '_arm'
+    plat = platform.system().lower() + "_" + arch
     try:
-        arch = 'x86_64' if sys.maxsize > 2 ** 32 else 'i386'
-        if 'arm' in os.uname()[4]:
-            arch += '_arm'
-        plat = platform.system().lower() + "_" + arch
-
         url = PLATFORMS[plat]
+
+        logger.debug("Platform to download: {}".format(plat))
     except KeyError:
         raise PyngrokNgrokInstallError("\"{}\" is not a supported platform".format(plat))
 

--- a/pyngrok/installer.py
+++ b/pyngrok/installer.py
@@ -2,6 +2,7 @@ import logging
 import os
 import platform
 import shutil
+import sys
 import tempfile
 import zipfile
 
@@ -25,9 +26,8 @@ PLATFORMS = {
     'darwin_i386': CDN_URL_PREFIX + "ngrok-stable-darwin-386.zip",
     'windows_x86_64': CDN_URL_PREFIX + "ngrok-stable-windows-amd64.zip",
     'windows_i386': CDN_URL_PREFIX + "ngrok-stable-windows-386.zip",
-    # TODO: need to validate the ARM keys
-    'linux_arm64': CDN_URL_PREFIX + "ngrok-stable-linux-arm64.zip",
-    'linux_arm': CDN_URL_PREFIX + "ngrok-stable-linux-arm.zip",
+    'linux_x86_64_arm': CDN_URL_PREFIX + "ngrok-stable-linux-arm64.zip",
+    'linux_i386_arm': CDN_URL_PREFIX + "ngrok-stable-linux-arm.zip",
     'linux_i386': CDN_URL_PREFIX + "ngrok-stable-linux-386.zip",
     'linux_x86_64': CDN_URL_PREFIX + "ngrok-stable-linux-amd64.zip",
     'freebsd_x86_64': CDN_URL_PREFIX + "ngrok-stable-freebsd-amd64.zip",
@@ -66,7 +66,10 @@ def install_ngrok(ngrok_path):
         os.mkdir(ngrok_dir)
 
     try:
-        plat = platform.system().lower() + "_" + platform.machine()
+        arch = 'x86_64' if sys.maxsize > 2 ** 32 else 'i386'
+        if 'arm' in os.uname()[4]:
+            arch += '_arm'
+        plat = platform.system().lower() + "_" + arch
 
         url = PLATFORMS[plat]
     except KeyError:

--- a/pyngrok/installer.py
+++ b/pyngrok/installer.py
@@ -15,13 +15,24 @@ from urllib.request import urlopen
 
 __author__ = "Alex Laird"
 __copyright__ = "Copyright 2019, Alex Laird"
-__version__ = "1.3.0"
+__version__ = "1.3.3"
 
 logger = logging.getLogger(__name__)
 
-DARWIN_DOWNLOAD_URL = "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-darwin-amd64.zip"
-WINDOWS_DOWNLOAD_URL = "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-windows-amd64.zip"
-LINUX_DARWIN_DOWNLOAD_URL = "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip"
+CDN_URL_PREFIX = "https://bin.equinox.io/c/4VmDzA7iaHb/"
+PLATFORMS = {
+    'darwin_x86_64': CDN_URL_PREFIX + "ngrok-stable-darwin-amd64.zip",
+    'darwin_i386': CDN_URL_PREFIX + "ngrok-stable-darwin-386.zip",
+    'windows_x86_64': CDN_URL_PREFIX + "ngrok-stable-windows-amd64.zip",
+    'windows_i386': CDN_URL_PREFIX + "ngrok-stable-windows-386.zip",
+    # TODO: need to validate the ARM keys
+    'linux_arm64': CDN_URL_PREFIX + "ngrok-stable-linux-arm64.zip",
+    'linux_arm': CDN_URL_PREFIX + "ngrok-stable-linux-arm.zip",
+    'linux_i386': CDN_URL_PREFIX + "ngrok-stable-linux-386.zip",
+    'linux_x86_64': CDN_URL_PREFIX + "ngrok-stable-linux-amd64.zip",
+    'freebsd_x86_64': CDN_URL_PREFIX + "ngrok-stable-freebsd-amd64.zip",
+    'freebsd_i386': CDN_URL_PREFIX + "ngrok-stable-freebsd-386.zip",
+}
 
 
 def get_ngrok_bin():
@@ -54,15 +65,12 @@ def install_ngrok(ngrok_path):
     if not os.path.exists(ngrok_dir):
         os.mkdir(ngrok_dir)
 
-    system = platform.system()
-    if system == "Darwin":
-        url = DARWIN_DOWNLOAD_URL
-    elif system == "Windows":  # pragma: no cover
-        url = WINDOWS_DOWNLOAD_URL
-    elif system == "Linux":  # pragma: no cover
-        url = LINUX_DARWIN_DOWNLOAD_URL
-    else:  # pragma: no cover
-        raise PyngrokNgrokInstallError("\"{}\" is not a supported platform".format(system))
+    try:
+        plat = platform.system().lower() + "_" + platform.machine()
+
+        url = PLATFORMS[plat]
+    except KeyError:
+        raise PyngrokNgrokInstallError("\"{}\" is not a supported platform".format(plat))
 
     try:
         download_path = _download_file(url)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 __author__ = "Alex Laird"
 __copyright__ = "Copyright 2018, Alex Laird"
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 
 with open("README.md", "r") as f:
     long_description = f.read()


### PR DESCRIPTION
In response to #11, adding support for all architectures supported by `ngrok` itself on the CDN. Needs further testing on a Pi to ensure the ARM constants returned by Python on 2 and 3 are consistent with what is assumed here.