### PR TITLE
Adding configurable timeout to requests

### DIFF
--- a/pyngrok/exception.py
+++ b/pyngrok/exception.py
@@ -1,6 +1,6 @@
 __author__ = "Alex Laird"
 __copyright__ = "Copyright 2019, Alex Laird"
-__version__ = "1.3.7"
+__version__ = "1.3.8"
 
 
 class PyngrokError(Exception):
@@ -23,6 +23,7 @@ class PyngrokNgrokError(PyngrokError):
 
     :var list ngrok_errors: A list of errors reported by the `ngrok` process.
     """
+
     def __init__(self, error, ngrok_errors=None):
         super(PyngrokNgrokError, self).__init__(error)
 
@@ -52,3 +53,16 @@ class PyngrokNgrokHTTPError(PyngrokNgrokError):
         self.message = message
         self.headers = headers
         self.body = body
+
+
+class PyngrokNgrokURLError(PyngrokNgrokError):
+    """
+    Raised when an error occurs when trying to initiate an API request.
+
+    :var string reason: The reason for the URL error.
+    """
+
+    def __init__(self, error, reason):
+        super(PyngrokNgrokURLError, self).__init__(error)
+
+        self.reason = reason

--- a/pyngrok/installer.py
+++ b/pyngrok/installer.py
@@ -16,7 +16,7 @@ from urllib.request import urlopen
 
 __author__ = "Alex Laird"
 __copyright__ = "Copyright 2019, Alex Laird"
-__version__ = "1.3.7"
+__version__ = "1.3.8"
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +33,7 @@ PLATFORMS = {
     'freebsd_x86_64': CDN_URL_PREFIX + "ngrok-stable-freebsd-amd64.zip",
     'freebsd_i386': CDN_URL_PREFIX + "ngrok-stable-freebsd-386.zip",
 }
+DEFAULT_DOWNLOAD_TIMEOUT = 10
 
 
 def get_ngrok_bin():
@@ -51,13 +52,17 @@ def get_ngrok_bin():
         raise PyngrokNgrokInstallError("\"{}\" is not a supported platform".format(system))
 
 
-def install_ngrok(ngrok_path):
+def install_ngrok(ngrok_path, timeout=None):
     """
     Download and install `ngrok` for the current system in the given location.
 
     :param ngrok_path: The path to where the `ngrok` binary will be downloaded.
     :type ngrok_path: string
+    :param timeout: The request timeout, in seconds.
+    :type timeout: float, optional
     """
+    timeout = timeout if timeout else DEFAULT_DOWNLOAD_TIMEOUT
+
     logger.debug("Binary not found at {}, installing ngrok ...".format(ngrok_path))
 
     ngrok_dir = os.path.dirname(ngrok_path)
@@ -77,7 +82,7 @@ def install_ngrok(ngrok_path):
         raise PyngrokNgrokInstallError("\"{}\" is not a supported platform".format(plat))
 
     try:
-        download_path = _download_file(url)
+        download_path = _download_file(url, timeout)
 
         with zipfile.ZipFile(download_path, "r") as zip_ref:
             logger.debug("Extracting ngrok binary to {} ...".format(download_path))
@@ -88,11 +93,11 @@ def install_ngrok(ngrok_path):
         raise PyngrokNgrokInstallError("An error occurred while downloading ngrok from {}: {}".format(url, e))
 
 
-def _download_file(url):
+def _download_file(url, timeout):
     logger.debug("Download ngrok from {} ...".format(url))
 
     local_filename = url.split("/")[-1]
-    response = urlopen(url)
+    response = urlopen(url, timeout=timeout)
 
     status_code = response.getcode()
     logger.debug("Response status code: {}".format(status_code))

--- a/pyngrok/installer.py
+++ b/pyngrok/installer.py
@@ -33,7 +33,7 @@ PLATFORMS = {
     'freebsd_x86_64': CDN_URL_PREFIX + "ngrok-stable-freebsd-amd64.zip",
     'freebsd_i386': CDN_URL_PREFIX + "ngrok-stable-freebsd-386.zip",
 }
-DEFAULT_DOWNLOAD_TIMEOUT = 10
+DEFAULT_DOWNLOAD_TIMEOUT = 6
 
 
 def get_ngrok_bin():

--- a/pyngrok/ngrok.py
+++ b/pyngrok/ngrok.py
@@ -7,13 +7,13 @@ import uuid
 from future.standard_library import install_aliases
 
 from pyngrok import process
-from pyngrok.exception import PyngrokNgrokHTTPError
+from pyngrok.exception import PyngrokNgrokHTTPError, PyngrokNgrokURLError
 from pyngrok.installer import get_ngrok_bin, install_ngrok
 
 install_aliases()
 
 from urllib.parse import urlencode
-from urllib.request import urlopen, Request, HTTPError
+from urllib.request import urlopen, Request, HTTPError, URLError
 
 __author__ = "Alex Laird"
 __copyright__ = "Copyright 2019, Alex Laird"
@@ -288,6 +288,8 @@ def api_request(uri, method="GET", data=None, params=None, timeout=4):
         raise PyngrokNgrokHTTPError("ngrok client exception, API returned {}: {}".format(status_code, response_data),
                                     e.url,
                                     status_code, e.msg, e.hdrs, response_data)
+    except URLError as e:
+        raise PyngrokNgrokURLError("ngrok client exception, URLError: {}".format(e.reason), e.reason)
 
 
 def run(args=None):

--- a/pyngrok/ngrok.py
+++ b/pyngrok/ngrok.py
@@ -17,7 +17,7 @@ from urllib.request import urlopen, Request, HTTPError
 
 __author__ = "Alex Laird"
 __copyright__ = "Copyright 2019, Alex Laird"
-__version__ = "1.3.7"
+__version__ = "1.3.8"
 
 logger = logging.getLogger(__name__)
 
@@ -233,7 +233,7 @@ def kill(ngrok_path=None):
     process.kill_process(ngrok_path)
 
 
-def api_request(uri, method="GET", data=None, params=None):
+def api_request(uri, method="GET", data=None, params=None, timeout=4):
     """
     Invoke an API request to the given URI, returning JSON data from the response as a dict.
 
@@ -245,6 +245,8 @@ def api_request(uri, method="GET", data=None, params=None):
     :type data: dict, optional
     :param params: The URL parameters.
     :type params: list, optional
+    :param timeout: The request timeout, in seconds.
+    :type timeout: float, optional
     :return: The response from the request.
     :rtype: dict
     """
@@ -262,7 +264,7 @@ def api_request(uri, method="GET", data=None, params=None):
     logger.debug("Making {} request to {} with data: {}".format(method, uri, data))
 
     try:
-        response = urlopen(request, data)
+        response = urlopen(request, data, timeout)
         response_data = response.read().decode("utf-8")
 
         status_code = response.getcode()

--- a/pyngrok/ngrok.py
+++ b/pyngrok/ngrok.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import socket
 import sys
 import uuid
 
@@ -280,6 +281,8 @@ def api_request(uri, method="GET", data=None, params=None, timeout=4):
             return None
 
         return json.loads(response_data)
+    except socket.timeout:
+        raise PyngrokNgrokURLError("ngrok client exception, URLError: timed out", "timed out")
     except HTTPError as e:
         response_data = e.read().decode("utf-8")
 

--- a/pyngrok/ngrok.py
+++ b/pyngrok/ngrok.py
@@ -194,6 +194,8 @@ def disconnect(public_url, ngrok_path=None, config_path=None):
 
             api_request("{}{}".format(api_url, tunnel.uri.replace("+", "%20")), "DELETE")
 
+            break
+
 
 def get_tunnels(ngrok_path=None):
     """

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 __author__ = "Alex Laird"
 __copyright__ = "Copyright 2019, Alex Laird"
-__version__ = "1.3.7"
+__version__ = "1.3.8"
 
 with open("README.md", "r") as f:
     long_description = f.read()

--- a/tests/testngrok.py
+++ b/tests/testngrok.py
@@ -157,10 +157,13 @@ class TestNgrok(NgrokTestCase):
     def test_api_request_timeout(self):
         # GIVEN
         current_process = ngrok.get_ngrok_process(config_path=self.config_path)
+        ngrok.connect(config_path=self.config_path)
+        time.sleep(1)
+        tunnels = ngrok.get_tunnels()
 
         # WHEN
         with self.assertRaises(PyngrokNgrokURLError) as cm:
-            ngrok.api_request("{}/api/{}".format(current_process.api_url, "tunnels"), "DELETE", timeout=0.0001)
+            ngrok.api_request("{}/api/{}".format(current_process.api_url, tunnels[0].uri.replace("+", "%20")), "DELETE", timeout=0.0001)
 
         # THEN
         self.assertIn("timed out", cm.exception.reason)

--- a/tests/testngrok.py
+++ b/tests/testngrok.py
@@ -4,12 +4,12 @@ import uuid
 import mock
 
 from pyngrok import ngrok, process
-from pyngrok.exception import PyngrokNgrokHTTPError
+from pyngrok.exception import PyngrokNgrokHTTPError, PyngrokNgrokURLError
 from .testcase import NgrokTestCase
 
 __author__ = "Alex Laird"
 __copyright__ = "Copyright 2019, Alex Laird"
-__version__ = "1.3.7"
+__version__ = "1.3.8"
 
 
 class TestNgrok(NgrokTestCase):
@@ -106,6 +106,36 @@ class TestNgrok(NgrokTestCase):
         # THEN
         self.assertIn("807ad30a-73be-48d8", contents)
 
+    def test_api_get_request_success(self):
+        # GIVEN
+        current_process = ngrok.get_ngrok_process(config_path=self.config_path)
+        ngrok.connect(config_path=self.config_path)
+        time.sleep(1)
+        tunnel = ngrok.get_tunnels()[0]
+
+        # WHEN
+        response = ngrok.api_request("{}{}".format(current_process.api_url, tunnel.uri.replace("+", "%20")), "GET")
+
+        # THEN
+        self.assertEqual(tunnel.name, response['name'])
+
+    def test_api_request_delete_data_updated(self):
+        # GIVEN
+        current_process = ngrok.get_ngrok_process(config_path=self.config_path)
+        ngrok.connect(config_path=self.config_path)
+        time.sleep(1)
+        tunnels = ngrok.get_tunnels()
+        self.assertEqual(len(tunnels), 2)
+
+        # WHEN
+        response = ngrok.api_request("{}{}".format(current_process.api_url, tunnels[0].uri.replace("+", "%20")),
+                                     "DELETE")
+
+        # THEN
+        self.assertIsNone(response)
+        tunnels = ngrok.get_tunnels()
+        self.assertEqual(len(tunnels), 1)
+
     def test_api_request_fails(self):
         # GIVEN
         current_process = ngrok.get_ngrok_process(config_path=self.config_path)
@@ -123,3 +153,14 @@ class TestNgrok(NgrokTestCase):
         self.assertEqual(400, cm.exception.status_code)
         self.assertIn("invalid tunnel configuration", str(cm.exception))
         self.assertIn("protocol name", str(cm.exception))
+
+    def test_api_request_timeout(self):
+        # GIVEN
+        current_process = ngrok.get_ngrok_process(config_path=self.config_path)
+
+        # WHEN
+        with self.assertRaises(PyngrokNgrokURLError) as cm:
+            ngrok.api_request("{}/api/{}".format(current_process.api_url, "tunnels"), "DELETE", timeout=0.0001)
+
+        # THEN
+        self.assertIn("timed out", cm.exception.reason)

--- a/tests/testngrok.py
+++ b/tests/testngrok.py
@@ -163,7 +163,7 @@ class TestNgrok(NgrokTestCase):
 
         # WHEN
         with self.assertRaises(PyngrokNgrokURLError) as cm:
-            ngrok.api_request("{}/api/{}".format(current_process.api_url, tunnels[0].uri.replace("+", "%20")), "DELETE", timeout=0.0001)
+            ngrok.api_request("{}{}".format(current_process.api_url, tunnels[0].uri.replace("+", "%20")), "DELETE", timeout=0.0001)
 
         # THEN
         self.assertIn("timed out", cm.exception.reason)

--- a/tests/testprocess.py
+++ b/tests/testprocess.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse
 
 __author__ = "Alex Laird"
 __copyright__ = "Copyright 2019, Alex Laird"
-__version__ = "1.3.7"
+__version__ = "1.3.8"
 
 
 class TestProcess(NgrokTestCase):


### PR DESCRIPTION
Per issue #17, adding configurable timeout for `urlopen` actions.