### PR TITLE
Fix ValueError in NgrokLog when message contains = character

### DIFF
--- a/pyngrok/process.py
+++ b/pyngrok/process.py
@@ -206,7 +206,7 @@ class NgrokLog:
             if "=" not in i:
                 continue
 
-            key, value = i.split("=")
+            key, value = i.split("=", 1)  # the value may contain additional "=" characters
 
             if key == "lvl":
                 value = value.upper()

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -8,6 +8,7 @@ from mock import mock
 from pyngrok import process, installer, conf, ngrok
 from pyngrok.conf import PyngrokConfig
 from pyngrok.exception import PyngrokNgrokError
+from pyngrok.process import NgrokLog
 from .testcase import NgrokTestCase
 
 install_aliases()
@@ -181,6 +182,10 @@ class TestProcess(NgrokTestCase):
         self.given_ngrok_installed(self.pyngrok_config.ngrok_path)
 
         # WHEN
+        assert(NgrokLog("lvl=INFO\nmsg=Test").lvl == "INFO")
+        assert(NgrokLog("lvl=WARN\nmsg=Test=Test").lvl == "WARNING")
+        assert(NgrokLog("lvl=ERR\nno_msg").lvl == "ERROR")
+        assert(NgrokLog("lvl=CRIT").lvl == "CRITICAL")
         ngrok_process = process._start_process(self.pyngrok_config)
 
         # THEN


### PR DESCRIPTION
**Description**
This PR fixes a ValueError exception when the ngrok process outputs a log line that includes one or more "=" characters in the body of the message, eg: `err=Get https://dns.google.com/resolve?cd=true&name=tunnel.eu.ngrok.com&type=AAAA: dial tcp: lookup dns.google.com on 127.0.0.53:53: server misbehaving`

`
**Issues**
n/a

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Testing Done**
To trigger the above message, I disconnected my network while pyngrok had a tunnel open.

**Checklist**
- [x] My code follows the PEP 8 style guidelines for Python
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my change is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
