### PR TITLE
port/addr is local dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [4.1.4](https://github.com/alexdlaird/pyngrok/compare/4.1.3...4.1.4) - 2020-07-05
 ### Fixed
-- Inconsistency support for a local directory (ex. `file:///`) being passed as `ngrok.connect()`'s `port`. This is valid, and `ngrok` will use its built-in fileserver for the tunnel.
+- Inconsistent support for a local directory (ex. `file:///`) being passed as `ngrok.connect()`'s `port`. This is valid, and `ngrok` will use its built-in fileserver for the tunnel.
 
 ## [4.1.3](https://github.com/alexdlaird/pyngrok/compare/4.1.2...4.1.3) - 2020-06-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alexdlaird/pyngrok/compare/4.1.3...HEAD)
+## [Unreleased](https://github.com/alexdlaird/pyngrok/compare/4.1.4...HEAD)
+
+## [4.1.4](https://github.com/alexdlaird/pyngrok/compare/4.1.3...4.1.4) - 2020-07-05
+### Fixed
+- Inconsistency support for a local directory (ex. `file:///`) being passed as `ngrok.connect()`'s `port`. This is valid, and `ngrok` will use its built-in fileserver for the tunnel.
 
 ## [4.1.3](https://github.com/alexdlaird/pyngrok/compare/4.1.2...4.1.3) - 2020-06-21
 ### Fixed

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -182,6 +182,16 @@ can be accomplished by using :code:`pyngrok` to open a :code:`tcp` tunnel to the
     ngrok.connect(3306, "tcp", options={"remote_addr": "1.tcp.ngrok.io:12345"})
 
 
+We can also serve up local directories via `ngrok's built-in fileserver <https://ngrok.com/docs#http-file-urls>`_.
+
+.. code-block:: python
+
+    from pyngrok import ngrok
+
+    # Open a tunnel to a local file server
+    ngrok.connect("file:///")
+
+
 Configuration
 -------------
 

--- a/pyngrok/ngrok.py
+++ b/pyngrok/ngrok.py
@@ -18,6 +18,11 @@ from urllib.parse import urlencode
 from urllib.request import urlopen, Request, HTTPError, URLError
 
 try:
+    from urllib.parse import quote_plus
+except ImportError:  # pragma: no cover
+    from urllib import quote_plus
+
+try:
     from http import HTTPStatus as StatusCodes
 except ImportError:  # pragma: no cover
     try:
@@ -27,7 +32,7 @@ except ImportError:  # pragma: no cover
 
 __author__ = "Alex Laird"
 __copyright__ = "Copyright 2020, Alex Laird"
-__version__ = "4.1.3"
+__version__ = "4.1.4"
 
 logger = logging.getLogger(__name__)
 
@@ -129,7 +134,7 @@ def get_ngrok_process(pyngrok_config=None):
     return process.get_process(pyngrok_config)
 
 
-def connect(port=80, proto="http", name=None, options=None, pyngrok_config=None):
+def connect(port="80", proto="http", name=None, options=None, pyngrok_config=None):
     """
     Establish a new :code:`ngrok` tunnel to the given port and protocol, returning the connected
     public URL that tunnels to the local port.
@@ -140,8 +145,9 @@ def connect(port=80, proto="http", name=None, options=None, pyngrok_config=None)
     If :code:`ngrok` is not running, calling this method will first start a process with
     :class:`~pyngrok.conf.PyngrokConfig`.
 
-    :param port: The local port to which to tunnel, defaults to 80.
-    :type port: int, optional
+    :param port: The local port to which to tunnel, defaults to 80. Can also be
+        a `local directory <https://ngrok.com/docs#http-file-urls>`_.
+    :type port: str, optional
     :param proto: The protocol to tunnel, defaults to "http".
     :type proto: str, optional
     :param name: A friendly name for the tunnel.
@@ -159,9 +165,11 @@ def connect(port=80, proto="http", name=None, options=None, pyngrok_config=None)
     if pyngrok_config is None:
         pyngrok_config = PyngrokConfig()
 
+    port = str(port)
+
     config = {
-        "name": name if name else "{}-{}-{}".format(proto, port, uuid.uuid4()),
-        "addr": str(port),
+        "name": name if name else "{}-{}-{}".format(proto, quote_plus(port), uuid.uuid4()),
+        "addr": port,
         "proto": proto
     }
     options.update(config)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 __author__ = "Alex Laird"
 __copyright__ = "Copyright 2020, Alex Laird"
-__version__ = "4.1.3"
+__version__ = "4.1.4"
 
 with open("README.md", "r") as f:
     long_description = f.read()


### PR DESCRIPTION
Addresses issue #50, where `addr` can actually be a local directory (ex. "file:///") and ngrok will serve up a fileserver.

`addr` is actually represented by `pyngrok`'s `port` var on `ngrok.connect()`, which perhaps should be revisited in a future, breaking release and renamed to`addr` since it doesn't just need to be a `port`. Not addressed in this PR, however, since we only want non-breaking changes.