### PR TITLE
Add option for sending `start_new_session` to Popen

### DIFF
--- a/pyngrok/conf.py
+++ b/pyngrok/conf.py
@@ -39,6 +39,8 @@ class PyngrokConfig:
     :vartype max_logs: int
     :var request_timeout: The max timeout when making requests to :code:`ngrok`'s API.
     :vartype request_timeout: float
+    :var start_new_session: Passed to :code:`subprocess.Popen` when launching :code:`ngrok`.  Requires Python 3.
+    :vartype start_new_session: bool
     """
 
     def __init__(self,
@@ -50,7 +52,8 @@ class PyngrokConfig:
                  log_event_callback=None,
                  startup_timeout=15,
                  max_logs=100,
-                 request_timeout=4):
+                 request_timeout=4,
+                 start_new_session=False):
         self.ngrok_path = DEFAULT_NGROK_PATH if ngrok_path is None else ngrok_path
         self.config_path = DEFAULT_CONFIG_PATH if config_path is None else config_path
         self.auth_token = auth_token
@@ -60,3 +63,4 @@ class PyngrokConfig:
         self.startup_timeout = startup_timeout
         self.max_logs = max_logs
         self.request_timeout = request_timeout
+        self.start_new_session = start_new_session

--- a/pyngrok/process.py
+++ b/pyngrok/process.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shlex
 import subprocess
+import sys
 import threading
 import time
 
@@ -372,7 +373,12 @@ def _start_process(pyngrok_config):
         logger.info("Starting ngrok in region: {}".format(pyngrok_config.region))
         start.append("--region={}".format(pyngrok_config.region))
 
-    proc = subprocess.Popen(start, stdout=subprocess.PIPE, universal_newlines=True)
+    popen_kwargs = {'stdout': subprocess.PIPE,  'universal_newlines' : True}
+    if sys.version_info.major >= 3:
+        popen_kwargs.update(start_new_session=pyngrok_config.start_new_session)
+    elif pyngrok_config.start_new_session:
+        logger.warning("Ignoring start_new_session=True, which requires Python 3")
+    proc = subprocess.Popen(start, **popen_kwargs)
     atexit.register(_terminate_process, proc)
 
     logger.info("ngrok process starting: {}".format(proc.pid))

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -221,6 +221,21 @@ class TestProcess(NgrokTestCase):
             self.assertIsNotNone(log.lvl)
             self.assertIsNotNone(log.msg)
 
+    def test_start_new_session(self):
+        # GIVEN
+        self.given_ngrok_installed(self.pyngrok_config.ngrok_path)
+
+        # WHEN
+        config = self.pyngrok_config
+        config.start_new_session = True
+        ngrok_process = process._start_process(self.pyngrok_config)
+
+        # THEN
+        for log in ngrok_process.logs:
+            self.assertIsNotNone(log.t)
+            self.assertIsNotNone(log.lvl)
+            self.assertIsNotNone(log.msg)
+
     def test_log_event_callback_and_max_logs(self):
         # GIVEN
         self.given_ngrok_installed(self.pyngrok_config.ngrok_path)


### PR DESCRIPTION
**Description**
In my jupyter notebook / google colab workflow, I sometime have to interrupt execution of a long-running cell.  Currently, if I had opened `ngrok` via `pyngrok` (using the master branch) somewhere in the notebook, the act of interrupting an unrelated cell causes the ngrok process to be terminated.  As a simple work-around, passing through `start_new_session` to `subprocess.Popen` resolves the issue.

I've put a minimal reproduction, and evidence of this fix [here](https://colab.research.google.com/drive/1ysSurAUTJtYJMDGuDRpZeoPmP_39-cUC).  PTAL.

Unfortunately, my repro requires both jupyter and some human interaction (unless i automate it), so I don't have a simple test to offer.

**Type of Change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alexdlaird/pyngrok/54)
<!-- Reviewable:end -->
