### PR TITLE
Allow for cleanup of defunct ngrok process after kill()

### DIFF
--- a/pyngrok/process.py
+++ b/pyngrok/process.py
@@ -308,6 +308,7 @@ def kill_process(ngrok_path):
 
         try:
             ngrok_process.proc.kill()
+            ngrok_process.proc.wait()
         except OSError as e:
             # If the process was already killed, nothing to do but cleanup state
             if e.errno != 3:


### PR DESCRIPTION
**Description**
Added wait() after kill() in kill_process() method to make sure defunct ngrok process is cleaned up properly

**Issues**
#58 

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Testing Done**
Tested with test_process.py - specifically changed behavior of test_start_process_port_in_use() in that failed start of 2nd ngrok process no longer results in a zombie process.
Also tested in live application using `sudo kill -SIGSTOP` to externally terminate ngrok process and letting application do cleanup.

Tested on Linux Mint x64 and Raspbian ARM platforms.  NOT tested on windows or Mac.

**Checklist**
- [x] My code follows the PEP 8 style guidelines for Python
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in particularly hard-to-understand areas
- [ ] If applicable, I have made corresponding changes to the documentation
- [ ] I have added tests that prove my change is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
