### PR TITLE
Return an https URL when option `bind_tls` is enabled

### DIFF
--- a/pyngrok/ngrok.py
+++ b/pyngrok/ngrok.py
@@ -180,7 +180,7 @@ def connect(port="80", proto="http", name=None, options=None, pyngrok_config=Non
     tunnel = NgrokTunnel(api_request("{}/api/{}".format(api_url, "tunnels"), method="POST", data=options,
                                      timeout=pyngrok_config.request_timeout))
 
-    if proto == "http" and ("bind_tls" not in options or options["bind_tls"] is not False):
+    if proto == "http" and ("bind_tls" not in options or options["bind_tls"] is False):
         tunnel.public_url = tunnel.public_url.replace("https", "http")
 
     return tunnel.public_url


### PR DESCRIPTION
**Description**
Fix bug reported in https://github.com/alexdlaird/pyngrok/issues/62

**Issues**
https://github.com/alexdlaird/pyngrok/issues/62


**Test plan:**
```
from pyngrok import ngrok
print(ngrok.connect(port="5000", proto="http", options={"bind_tls": True}))
```
output: https://X.ngrok.io
prefix is `https` as expected

**other use cases are not affected:**
```
from pyngrok import ngrok
print(ngrok.connect(port="5000", proto="http"))
```
output: http://X.ngrok.io

```
from pyngrok import ngrok
print(ngrok.connect(port="5000", proto="http", options={"bind_tls": False}))
```
output: http://X.ngrok.io

All outputs are as expected


**Environment:**
```
PYNGROK VERSION: 4.1.9
NGROK VERSION: 2.3.35
```

Tested on: https://colab.research.google.com/

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**
- [x] My code follows the PEP 8 style guidelines for Python
- [x] I have performed a self-review of my own code
- [x] I have commented my code in particularly hard-to-understand areas
- [x] If applicable, I have made corresponding changes to the documentation
- [x] I have added tests that prove my change is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
