### PR TITLE
RC for 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased](https://github.com/alexdlaird/pyngrok/compare/4.2.0...HEAD)
 
 ## [4.2.0](https://github.com/alexdlaird/pyngrok/compare/4.1.14...4.2.0) - TBD
+**4.2.x will not continue to be a supported version of `pyngrok`. This release is meant to ease migration between 4.1.x
+and 5.0.0. If you need Python 2.7 support or do not want to mess with breaking changes from 5.0.0,
+pin `pyngrok>=4.1,<4.2`.**
+
 ### Added
 - [ngrok.connect()](https://pyngrok.readthedocs.io/en/4.2.0/api.html#pyngrok.ngrok.connect) replaced `options` with kwargs, maintained backwards compatibility. Support for passing `options` as a dict will be removed in 5.0.0, unpack the dict as `kwargs`.
 - [ngrok.connect()](https://pyngrok.readthedocs.io/en/4.2.0/api.html#pyngrok.ngrok.connect) added `return_ngrok_tunnel` to its args, which defaults to `False`. This will be removed and `True` will be the default behavior in 5.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 do not want to mess with **breaking changes coming in 5.0.0**, pin `pyngrok>=4.1,<4.2`.
 
 ### Added
-- [ngrok.connect()](https://pyngrok.readthedocs.io/en/4.2.0/api.html#pyngrok.ngrok.connect) replaced `options` with kwargs, maintained backwards compatibility. Support for passing `options` as a dict will be removed in 5.0.0, unpack the dict as `kwargs`.
+- [ngrok.connect()](https://pyngrok.readthedocs.io/en/4.2.0/api.html#pyngrok.ngrok.connect) replaced `options` with `kwargs`, maintained backwards compatibility. Support for passing `options` as a dict will be removed in 5.0.0, unpack the dict as `kwargs`.
 - [ngrok.connect()](https://pyngrok.readthedocs.io/en/4.2.0/api.html#pyngrok.ngrok.connect) added `return_ngrok_tunnel` to its args, which defaults to `False` for backwards compatibility. This will default to `True` in 5.0.0, and the flag will be removed.
 - [conf.get_default()](https://pyngrok.readthedocs.io/en/4.2.0/api.html#pyngrok.conf.get_default). This replaces the need to directly reference `conf.DEFAULT_PYNGROK_CONFIG`, which will be removed in 5.0.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased](https://github.com/alexdlaird/pyngrok/compare/4.2.0...HEAD)
 
 ## [4.2.0](https://github.com/alexdlaird/pyngrok/compare/4.1.14...4.2.0) - TBD
-**4.2.x will not continue to be a supported version of `pyngrok`. This release is meant to ease migration between 4.1.x
-and 5.0.0. If you need Python 2.7 support or do not want to mess with breaking changes from 5.0.0,
-pin `pyngrok>=4.1,<4.2`.**
+
+**4.2.x will not continue to be a supported** version of `pyngrok`. This release is meant to **ease migration between
+4.1.x and 5.0.0** by adding backwards compatible versions of some of those features. If you need Python 2.7 support or
+do not want to mess with **breaking changes coming in 5.0.0**, pin `pyngrok>=4.1,<4.2`.
 
 ### Added
 - [ngrok.connect()](https://pyngrok.readthedocs.io/en/4.2.0/api.html#pyngrok.ngrok.connect) replaced `options` with kwargs, maintained backwards compatibility. Support for passing `options` as a dict will be removed in 5.0.0, unpack the dict as `kwargs`.
-- [ngrok.connect()](https://pyngrok.readthedocs.io/en/4.2.0/api.html#pyngrok.ngrok.connect) added `return_ngrok_tunnel` to its args, which defaults to `False`. This will be removed and `True` will be the default behavior in 5.0.0.
+- [ngrok.connect()](https://pyngrok.readthedocs.io/en/4.2.0/api.html#pyngrok.ngrok.connect) added `return_ngrok_tunnel` to its args, which defaults to `False` for backwards compatibility. This will default to `True` in 5.0.0, and the flag will be removed.
+- [conf.get_default()](https://pyngrok.readthedocs.io/en/4.2.0/api.html#pyngrok.conf.get_default). This replaces the need to directly reference `conf.DEFAULT_PYNGROK_CONFIG`, which will be removed in 5.0.0.
 
 ## [4.1.14](https://github.com/alexdlaird/pyngrok/compare/4.1.13...4.1.14) - TBD
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/alexdlaird/pyngrok/compare/4.2.0...HEAD)
 
-## [4.2.0](https://github.com/alexdlaird/pyngrok/compare/4.1.14...4.2.0) - TBD
+## [4.2.0](https://github.com/alexdlaird/pyngrok/compare/4.1.14...4.2.0) - 2020-10-11
 
 The next release, 5.0.0, contains breaking changes, including dropping support for Python 2.7. 4.2.x is meant to ease
 migration between 4.1.x and 5.0.0 and should not be pinned, as it will not be supported after 5.0.0 is released. To

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased](https://github.com/alexdlaird/pyngrok/compare/4.1.13...HEAD)
 ### Added
 - `refresh_metrics()` to [NgrokTunnel](https://pyngrok.readthedocs.io/en/develop/api.html#pyngrok.ngrok.NgrokTunnel.refresh_metrics).
- - Documentation improvements.
+- [ngrok.connect()](https://pyngrok.readthedocs.io/en/develop/api.html#pyngrok.ngrok.connect) replaced `options` with kwargs, maintained backwards compatibility. Support for passing `options` as a dict will be removed in 5.0.0, unpack the dict as `kwargs`.
+- [ngrok.connect()](https://pyngrok.readthedocs.io/en/develop/api.html#pyngrok.ngrok.connect) added `return_ngrok_tunnel` to its args, which defaults to `False`. This will be removed and `True` will be the default behavior in 5.0.0.
+- Documentation improvements.
 
 ## [4.1.13](https://github.com/alexdlaird/pyngrok/compare/4.1.12...4.1.13) - 2020-10-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,16 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alexdlaird/pyngrok/compare/4.1.13...HEAD)
+## [Unreleased](https://github.com/alexdlaird/pyngrok/compare/4.2.0...HEAD)
+
+## [4.2.0](https://github.com/alexdlaird/pyngrok/compare/4.1.14...4.2.0) - TBD
 ### Added
-- `refresh_metrics()` to [NgrokTunnel](https://pyngrok.readthedocs.io/en/develop/api.html#pyngrok.ngrok.NgrokTunnel.refresh_metrics).
 - [ngrok.connect()](https://pyngrok.readthedocs.io/en/develop/api.html#pyngrok.ngrok.connect) replaced `options` with kwargs, maintained backwards compatibility. Support for passing `options` as a dict will be removed in 5.0.0, unpack the dict as `kwargs`.
 - [ngrok.connect()](https://pyngrok.readthedocs.io/en/develop/api.html#pyngrok.ngrok.connect) added `return_ngrok_tunnel` to its args, which defaults to `False`. This will be removed and `True` will be the default behavior in 5.0.0.
+
+## [4.1.14](https://github.com/alexdlaird/pyngrok/compare/4.1.13...4.1.14) - TBD
+### Added
+- `refresh_metrics()` to [NgrokTunnel](https://pyngrok.readthedocs.io/en/develop/api.html#pyngrok.ngrok.NgrokTunnel.refresh_metrics).
 - Documentation improvements.
 
 ## [4.1.13](https://github.com/alexdlaird/pyngrok/compare/4.1.12...4.1.13) - 2020-10-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ do not want to mess with **breaking changes coming in 5.0.0**, pin `pyngrok>=4.1
 ### Added
 - [ngrok.connect()](https://pyngrok.readthedocs.io/en/4.2.0/api.html#pyngrok.ngrok.connect) replaced `options` with `kwargs`, maintained backwards compatibility. Support for passing `options` as a dict will be removed in 5.0.0, unpack the dict as `kwargs`.
 - [ngrok.connect()](https://pyngrok.readthedocs.io/en/4.2.0/api.html#pyngrok.ngrok.connect) added `return_ngrok_tunnel` to its args, which defaults to `False` for backwards compatibility. This will default to `True` in 5.0.0, and the flag will be removed.
-- [conf.get_default()](https://pyngrok.readthedocs.io/en/4.2.0/api.html#pyngrok.conf.get_default). This replaces the need to directly reference `conf.DEFAULT_PYNGROK_CONFIG`, which will be removed in 5.0.0.
+- [conf.get_default()](https://pyngrok.readthedocs.io/en/4.2.0/api.html#pyngrok.conf.get_default), replacing the need to directly reference `conf.DEFAULT_PYNGROK_CONFIG`, which will be removed in 5.0.0.
 
 ## [4.1.14](https://github.com/alexdlaird/pyngrok/compare/4.1.13...4.1.14) - TBD
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [4.2.0](https://github.com/alexdlaird/pyngrok/compare/4.1.14...4.2.0) - TBD
 
-**4.2.x will not continue to be a supported** version of `pyngrok`. This release is meant to **ease migration between
-4.1.x and 5.0.0** by adding backwards compatible versions of some of those features. If you need Python 2.7 support or
-do not want to mess with **breaking changes coming in 5.0.0**, pin `pyngrok>=4.1,<4.2`.
+The next release, 5.0.0, contains breaking changes, including dropping support for Python 2.7. 4.2.x is meant to ease
+migration between 4.1.x and 5.0.0 and should not be pinned, as it will not be supported after 5.0.0 is released. To
+prepare for these breaking changes, see the changelog below. To avoid these breaking changes altogether, or if
+Python 2.7 support is still needed, pin `pyngrok>=4.1,<4.2`.
 
 ### Added
 - [ngrok.connect()](https://pyngrok.readthedocs.io/en/4.2.0/api.html#pyngrok.ngrok.connect) replaced `options` with `kwargs`, maintained backwards compatibility. Support for passing `options` as a dict will be removed in 5.0.0, unpack the dict as `kwargs`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [4.2.0](https://github.com/alexdlaird/pyngrok/compare/4.1.14...4.2.0) - TBD
 ### Added
-- [ngrok.connect()](https://pyngrok.readthedocs.io/en/develop/api.html#pyngrok.ngrok.connect) replaced `options` with kwargs, maintained backwards compatibility. Support for passing `options` as a dict will be removed in 5.0.0, unpack the dict as `kwargs`.
-- [ngrok.connect()](https://pyngrok.readthedocs.io/en/develop/api.html#pyngrok.ngrok.connect) added `return_ngrok_tunnel` to its args, which defaults to `False`. This will be removed and `True` will be the default behavior in 5.0.0.
+- [ngrok.connect()](https://pyngrok.readthedocs.io/en/4.2.0/api.html#pyngrok.ngrok.connect) replaced `options` with kwargs, maintained backwards compatibility. Support for passing `options` as a dict will be removed in 5.0.0, unpack the dict as `kwargs`.
+- [ngrok.connect()](https://pyngrok.readthedocs.io/en/4.2.0/api.html#pyngrok.ngrok.connect) added `return_ngrok_tunnel` to its args, which defaults to `False`. This will be removed and `True` will be the default behavior in 5.0.0.
 
 ## [4.1.14](https://github.com/alexdlaird/pyngrok/compare/4.1.13...4.1.14) - TBD
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ the command line.
 ## 4.1.x to 5.0.0
 
 The next release, 5.0.0, contains breaking changes, including dropping support for Python 2.7. 4.2.x is meant to ease
-migration between 4.1.x and 5.0.0. [See the changelog](https://github.com/alexdlaird/pyngrok/blob/master/CHANGELOG.md#420---2020-10-11)
-for more details on how to prepare for this.
+migration between 4.1.x and 5.0.0 and should not be pinned, as it will not be supported after 5.0.0 is released. To
+prepare for these breaking changes, [see the changelog](https://github.com/alexdlaird/pyngrok/blob/master/CHANGELOG.md#420---2020-10-11).
+To avoid these breaking changes altogether, or if Python 2.7 support is still needed, pin `pyngrok>=4.1,<4.2`.
 
 ## Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ conda install -c conda-forge pyngrok
 That's it! `pyngrok` is now available as a package to our Python projects, and `ngrok` is now available from
 the command line.
 
+## 4.1.x to 5.0.0
+
+Breaking changes are coming in 5.0.0, and 4.2.x is meant to ease migration between 4.1.x and 5.0.0.
+[See the changelog](https://github.com/alexdlaird/pyngrok/blob/master/CHANGELOG.md#420---2020-10-11) for more details
+on how to prepare for this.
+
 ## Basic Usage
 
 To open a tunnel, use the [`connect`](https://pyngrok.readthedocs.io/en/latest/api.html#pyngrok.ngrok.connect) method,

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ the command line.
 
 ## 4.1.x to 5.0.0
 
-Breaking changes are coming in 5.0.0, and 4.2.x is meant to ease migration between 4.1.x and 5.0.0.
-[See the changelog](https://github.com/alexdlaird/pyngrok/blob/master/CHANGELOG.md#420---2020-10-11) for more details
-on how to prepare for this.
+The next release, 5.0.0, contains breaking changes, including dropping support for Python 2.7. 4.2.x is meant to ease
+migration between 4.1.x and 5.0.0. [See the changelog](https://github.com/alexdlaird/pyngrok/blob/master/CHANGELOG.md#420---2020-10-11)
+for more details on how to prepare for this.
 
 ## Basic Usage
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 4.2.x   | :x:                |
 | 4.1.x   | :white_check_mark: |
 | < 4.1.x | :x:                |
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -197,7 +197,7 @@ can be accomplished by using ``pyngrok`` to open a ``tcp`` tunnel to the desired
 
     # Open a tunnel to MySQL with a Reserved TCP Address
     ngrok.connect(3306, "tcp",
-                  remote_addr="1.tcp.ngrok.io:12345")
+                  options={"remote_addr": "1.tcp.ngrok.io:12345"})
 
 
 We can also serve up local directories via `ngrok's built-in fileserver <https://ngrok.com/docs#http-file-urls>`_.
@@ -295,10 +295,10 @@ Here is an example starting ``ngrok`` in Australia, then opening a tunnel with s
     from pyngrok.conf import PyngrokConfig
     from pyngrok import ngrok
 
+    options = {"subdomain": "foo", "auth": "username:password"}
     pyngrok_config = PyngrokConfig(region="au")
 
-    url = ngrok.connect(subdomain="foo",
-                        auth="username:password",
+    url = ngrok.connect(options=options,
                         pyngrok_config=pyngrok_config)
 
 Config File

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,8 +53,9 @@ and ``ngrok`` is now available `from the command line <#command-line-usage>`_.
 ==============
 
 The next release, 5.0.0, contains breaking changes, including dropping support for Python 2.7. 4.2.x is meant to ease
-migration between 4.1.x and 5.0.0. `See the changelog <https://github.com/alexdlaird/pyngrok/blob/master/CHANGELOG.md#420---2020-10-11>`_
-for more details on how to prepare for this.
+migration between 4.1.x and 5.0.0 and should not be pinned, as it will not be supported after 5.0.0 is released. To
+prepare for these breaking changes, `see the changelog <https://github.com/alexdlaird/pyngrok/blob/master/CHANGELOG.md#420---2020-10-11>`_
+To avoid these breaking changes altogether, or if Python 2.7 support is still needed, pin ``pyngrok>=4.1,<4.2``.
 
 Open a Tunnel
 =============

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,9 +52,9 @@ and ``ngrok`` is now available `from the command line <#command-line-usage>`_.
 4.1.x to 5.0.0
 ==============
 
-Breaking changes are coming in 5.0.0, and 4.2.x is meant to ease migration between 4.1.x and 5.0.0.
-`See the changelog <https://github.com/alexdlaird/pyngrok/blob/master/CHANGELOG.md#420---2020-10-11>`_ for more details
-on how to prepare for this.
+The next release, 5.0.0, contains breaking changes, including dropping support for Python 2.7. 4.2.x is meant to ease
+migration between 4.1.x and 5.0.0. `See the changelog <https://github.com/alexdlaird/pyngrok/blob/master/CHANGELOG.md#420---2020-10-11>`_
+for more details on how to prepare for this.
 
 Open a Tunnel
 =============

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -189,7 +189,7 @@ can be accomplished by using ``pyngrok`` to open a ``tcp`` tunnel to the desired
 
     # Open a tunnel to MySQL with a Reserved TCP Address
     ngrok.connect(3306, "tcp",
-                  options={"remote_addr": "1.tcp.ngrok.io:12345"})
+                  remote_addr="1.tcp.ngrok.io:12345")
 
 
 We can also serve up local directories via `ngrok's built-in fileserver <https://ngrok.com/docs#http-file-urls>`_.
@@ -287,10 +287,10 @@ Here is an example starting ``ngrok`` in Australia, then opening a tunnel with s
     from pyngrok.conf import PyngrokConfig
     from pyngrok import ngrok
 
-    options = {"subdomain": "foo", "auth": "username:password"}
     pyngrok_config = PyngrokConfig(region="au")
 
-    url = ngrok.connect(options=options,
+    url = ngrok.connect(subdomain="foo",
+                        auth="username:password",
                         pyngrok_config=pyngrok_config)
 
 Config File

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,6 +49,13 @@ or ``conda``:
 That's it! ``pyngrok`` is now available `as a package to our Python projects <#open-a-tunnel>`_,
 and ``ngrok`` is now available `from the command line <#command-line-usage>`_.
 
+4.1.x to 5.0.0
+==============
+
+Breaking changes are coming in 5.0.0, and 4.2.x is meant to ease migration between 4.1.x and 5.0.0.
+`See the changelog <https://github.com/alexdlaird/pyngrok/blob/master/CHANGELOG.md#420---2020-10-11>`_ for more details
+on how to prepare for this.
+
 Open a Tunnel
 =============
 

--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -43,7 +43,7 @@ same place.
 
             # Open a ngrok tunnel to the dev server
             public_url = ngrok.connect(port)
-            print(" * ngrok tunnel \"{}\" -> \"http://127.0.0.1:{}/\"".format(public_url, port))
+            print(" * ngrok tunnel \"{}\" -> \"http://127.0.0.1:{}\"".format(public_url, port))
 
             # Update any base URLs or webhooks to use the public ngrok URL
             app.config["BASE_URL"] = public_url
@@ -106,8 +106,8 @@ to do this is one of our ``apps.py`` by `extending AppConfig <https://docs.djang
                 port = addrport.port if addrport.netloc and addrport.port else 8000
 
                 # Open a ngrok tunnel to the dev server
-                public_url = ngrok.connect(port).rstrip("/")
-                print("ngrok tunnel \"{}\" -> \"http://127.0.0.1:{}/\"".format(public_url, port))
+                public_url = ngrok.connect(port)
+                print("ngrok tunnel \"{}\" -> \"http://127.0.0.1:{}\"".format(public_url, port))
 
                 # Update any base URLs or webhooks to use the public ngrok URL
                 settings.BASE_URL = public_url
@@ -169,7 +169,7 @@ we should add a variable that let's us configure from an environment variable wh
 
         # Open a ngrok tunnel to the dev server
         public_url = ngrok.connect(port)
-        logger.info("ngrok tunnel \"{}\" -> \"http://127.0.0.1:{}/\"".format(public_url, port))
+        logger.info("ngrok tunnel \"{}\" -> \"http://127.0.0.1:{}\"".format(public_url, port))
 
         # Update any base URLs or webhooks to use the public ngrok URL
         settings.BASE_URL = public_url
@@ -245,7 +245,7 @@ assumes we have also added ``!pip install flask`` to our dependency code block.
 
     # Open a ngrok tunnel to the HTTP server
     public_url = ngrok.connect(5000)
-    print(" * ngrok tunnel \"{}\" -> \"http://127.0.0.1:{}/\"".format(public_url, 5000))
+    print(" * ngrok tunnel \"{}\" -> \"http://127.0.0.1:{}\"".format(public_url, 5000))
 
     # Update any base URLs to use the public ngrok URL
     app.config["BASE_URL"] = public_url
@@ -392,7 +392,7 @@ server. We can use ``pyngrok`` to expose it to the web via a tunnel, as show in 
     httpd = HTTPServer(server_address, BaseHTTPRequestHandler)
 
     public_url = ngrok.connect(port)
-    print("ngrok tunnel \"{}\" -> \"http://127.0.0.1:{}/\"".format(public_url, port))
+    print("ngrok tunnel \"{}\" -> \"http://127.0.0.1:{}\"".format(public_url, port))
 
     try:
         # Block until CTRL-C or some other terminating event
@@ -440,7 +440,7 @@ Now create ``server.py`` with the following code:
 
     # Open a ngrok tunnel to the socket
     public_url = ngrok.connect(port, "tcp", options={"remote_addr": "{}:{}".format(host, port)})
-    print("ngrok tunnel \"{}\" -> \"tcp://127.0.0.1:{}/\"".format(public_url, port))
+    print("ngrok tunnel \"{}\" -> \"tcp://127.0.0.1:{}\"".format(public_url, port))
 
     while True:
         connection = None

--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -439,7 +439,7 @@ Now create ``server.py`` with the following code:
     sock.listen(1)
 
     # Open a ngrok tunnel to the socket
-    public_url = ngrok.connect(port, "tcp", remote_addr="{}:{}".format(host, port))
+    public_url = ngrok.connect(port, "tcp", options={"remote_addr": "{}:{}".format(host, port)})
     print("ngrok tunnel \"{}\" -> \"tcp://127.0.0.1:{}/\"".format(public_url, port))
 
     while True:

--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -439,7 +439,7 @@ Now create ``server.py`` with the following code:
     sock.listen(1)
 
     # Open a ngrok tunnel to the socket
-    public_url = ngrok.connect(port, "tcp", options={"remote_addr": "{}:{}".format(host, port)})
+    public_url = ngrok.connect(port, "tcp", remote_addr="{}:{}".format(host, port))
     print("ngrok tunnel \"{}\" -> \"tcp://127.0.0.1:{}/\"".format(public_url, port))
 
     while True:

--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -242,10 +242,11 @@ assumes we have also added ``!pip install flask`` to our dependency code block.
     os.environ["FLASK_ENV"] = "development"
 
     app = Flask(__name__)
+    port = 5000
 
     # Open a ngrok tunnel to the HTTP server
-    public_url = ngrok.connect(5000)
-    print(" * ngrok tunnel \"{}\" -> \"http://127.0.0.1:{}\"".format(public_url, 5000))
+    public_url = ngrok.connect(port)
+    print(" * ngrok tunnel \"{}\" -> \"http://127.0.0.1:{}\"".format(public_url, port))
 
     # Update any base URLs to use the public ngrok URL
     app.config["BASE_URL"] = public_url

--- a/pyngrok/conf.py
+++ b/pyngrok/conf.py
@@ -4,7 +4,7 @@ from pyngrok.installer import get_ngrok_bin
 
 __author__ = "Alex Laird"
 __copyright__ = "Copyright 2020, Alex Laird"
-__version__ = "4.1.13"
+__version__ = "4.2.0"
 
 BIN_DIR = os.path.normpath(os.path.join(os.path.abspath(os.path.dirname(__file__)), "bin"))
 DEFAULT_NGROK_PATH = os.path.join(BIN_DIR, get_ngrok_bin())
@@ -70,3 +70,14 @@ class PyngrokConfig:
 
 
 DEFAULT_PYNGROK_CONFIG = PyngrokConfig()
+
+
+def get_default():
+    """
+    Get the default config to be used with methods in the :mod:`~pyngrok.ngrok` module. To override the
+    default individually, the ``pyngrok_config`` keyword arg can also be passed to most of these methods.
+
+    :return: The default ``pyngrok_config``.
+    :rtype: PyngrokConfig
+    """
+    return DEFAULT_PYNGROK_CONFIG

--- a/pyngrok/ngrok.py
+++ b/pyngrok/ngrok.py
@@ -193,7 +193,7 @@ def connect(port="80", proto="http", name=None, pyngrok_config=None, return_ngro
     if "options" in options:
         logger.warning(
             "Support for passing \"options\" as a dict is deprecated and will be removed in 5.0.0, unpack the dict as kwargs")
-        options.update(options.get("options", {}))
+        options.update(options.pop("options", {}))
 
     port = str(port)
     if not name:

--- a/pyngrok/ngrok.py
+++ b/pyngrok/ngrok.py
@@ -26,7 +26,7 @@ except ImportError:  # pragma: no cover
 
 __author__ = "Alex Laird"
 __copyright__ = "Copyright 2020, Alex Laird"
-__version__ = "4.1.14"
+__version__ = "4.2.0"
 
 logger = logging.getLogger(__name__)
 

--- a/pyngrok/ngrok.py
+++ b/pyngrok/ngrok.py
@@ -218,7 +218,9 @@ def connect(port="80", proto="http", name=None, pyngrok_config=None, return_ngro
                          pyngrok_config=pyngrok_config, api_url=api_url)
 
     if proto == "http" and not options.get("bind_tls", False):
-        tunnel.public_url = tunnel.public_url.replace("https", "http")
+        tunnel = NgrokTunnel(api_request("{}{}%20%28http%29".format(api_url, tunnel.uri), method="GET",
+                                         timeout=pyngrok_config.request_timeout),
+                             pyngrok_config, api_url)
 
     if return_ngrok_tunnel:
         return tunnel

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 __author__ = "Alex Laird"
 __copyright__ = "Copyright 2020, Alex Laird"
-__version__ = "4.1.14"
+__version__ = "4.2.0"
 
 name = "pyngrok" if os.environ.get("BUILD_PACKAGE_AS_NGROK", "False") != "True" else "ngrok"
 


### PR DESCRIPTION
The next release, 5.0.0, contains breaking changes, including dropping support for Python 2.7. 4.2.x is meant to ease
migration between 4.1.x and 5.0.0 and should not be pinned, as it will not be supported after 5.0.0 is released. To
prepare for these breaking changes, see the changelog below. To avoid these breaking changes altogether, or if
Python 2.7 support is still needed, pin `pyngrok>=4.1,<4.2`.

### Added
- [ngrok.connect()](https://pyngrok.readthedocs.io/en/4.2.0/api.html#pyngrok.ngrok.connect) replaced `options` with `kwargs`, maintained backwards compatibility. Support for passing `options` as a dict will be removed in 5.0.0, unpack the dict as `kwargs`.
- [ngrok.connect()](https://pyngrok.readthedocs.io/en/4.2.0/api.html#pyngrok.ngrok.connect) added `return_ngrok_tunnel` to its args, which defaults to `False` for backwards compatibility. This will default to `True` in 5.0.0, and the flag will be removed.
- [conf.get_default()](https://pyngrok.readthedocs.io/en/4.2.0/api.html#pyngrok.conf.get_default), replacing the need to directly reference `conf.DEFAULT_PYNGROK_CONFIG`, which will be removed in 5.0.0.