### PR TITLE
Rely on ngrok's built-in retry mechanism for "failed to reconnect session" instead of forcing the binary to restart

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,8 @@ name: "CI/CD"
 
 on:
   push:
-    branches: [ main, develop ]
+    branches:
+      - "**"
   pull_request:
     branches: [ main, develop ]
   schedule:

--- a/pyngrok/conf.py
+++ b/pyngrok/conf.py
@@ -62,9 +62,6 @@ class PyngrokConfig:
     :vartype request_timeout: float
     :var start_new_session: Passed to :py:class:`subprocess.Popen` when launching ``ngrok``. (Python 3 and POSIX only)
     :vartype start_new_session: bool
-    :var reconnect_session_retries: The max number of times to retry establishing a new session with ``ngrok`` if the
-        connection fails on startup.
-    :vartype reconnect_session_retries: int
     """
 
     def __init__(self,
@@ -77,8 +74,7 @@ class PyngrokConfig:
                  startup_timeout=15,
                  max_logs=100,
                  request_timeout=4,
-                 start_new_session=False,
-                 reconnect_session_retries=0):
+                 start_new_session=False):
         self.ngrok_path = DEFAULT_NGROK_PATH if ngrok_path is None else ngrok_path
         self.config_path = DEFAULT_CONFIG_PATH if config_path is None else config_path
         self.auth_token = auth_token
@@ -89,7 +85,6 @@ class PyngrokConfig:
         self.max_logs = max_logs
         self.request_timeout = request_timeout
         self.start_new_session = start_new_session
-        self.reconnect_session_retries = reconnect_session_retries
 
 
 def get_default():

--- a/pyngrok/process.py
+++ b/pyngrok/process.py
@@ -77,7 +77,7 @@ class NgrokProcess:
             return
         elif self._line_has_error(log):
             self.startup_error = log.err
-        else:
+        elif log.msg:
             # Log ngrok startup states as they come in
             if "starting web service" in log.msg and log.addr is not None:
                 self.api_url = "http://{}".format(log.addr)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -251,9 +251,9 @@ class TestProcess(NgrokTestCase):
     @mock.patch("subprocess.Popen")
     def test_retry_session_connection_failure(self, mock_proc_readline):
         # GIVEN
-        log_line = "lvl=eror msg=\"failed to reconnect session\" err=EOF"
+        log_line = "lvl=eror msg=\"some error\" err=EOF"
         mock_proc_readline.return_value.stdout.readline.side_effect = [log_line, log_line, log_line]
-        pyngrok_config = self.copy_with_updates(self.pyngrok_config, reconnect_session_retries=2)
+        pyngrok_config = self.copy_with_updates(self.pyngrok_config)
         self.given_ngrok_installed(pyngrok_config)
 
         # WHEN
@@ -262,9 +262,9 @@ class TestProcess(NgrokTestCase):
 
         # THEN
         self.assertIsNotNone(cm)
-        self.assertEqual(cm.exception.ngrok_logs[-1].msg, "failed to reconnect session")
+        self.assertEqual(cm.exception.ngrok_logs[-1].msg, "some error")
         self.assertEqual(cm.exception.ngrok_error, "EOF")
-        self.assertEqual(mock_proc_readline.call_count, 3)
+        self.assertEqual(mock_proc_readline.call_count, 1)
         self.assertEqual(len(process._current_processes.keys()), 0)
 
     ################################################################################

--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -30,11 +30,7 @@ class NgrokTestCase(unittest.TestCase):
         config_path = os.path.join(self.config_dir, "config.yml")
 
         conf.DEFAULT_NGROK_CONFIG_PATH = config_path
-        self.pyngrok_config = PyngrokConfig(config_path=conf.DEFAULT_NGROK_CONFIG_PATH,
-                                            # When running parallel CI/CD tests against the same ngrok account, ngrok
-                                            # can start rejecting connections, which is easily mitigated with retries
-                                            # to ensure test stability
-                                            reconnect_session_retries=10)
+        self.pyngrok_config = PyngrokConfig(config_path=conf.DEFAULT_NGROK_CONFIG_PATH)
         conf.set_default(self.pyngrok_config)
 
         # ngrok's CDN can be flaky, so make sure its flakiness isn't reflect in our CI/CD test runs


### PR DESCRIPTION
Address issue #88.