### PR TITLE
Added SSL context, needed for downloading ngrok

### DIFF
--- a/pyngrok/installer.py
+++ b/pyngrok/installer.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import time
 import zipfile
+import ssl
 from http import HTTPStatus
 from urllib.request import urlopen
 
@@ -212,7 +213,7 @@ def _download_file(url, retries=0, **kwargs):
         logger.debug("Download ngrok from {} ...".format(url))
 
         local_filename = url.split("/")[-1]
-        response = urlopen(url, **kwargs)
+        response = urlopen(url, context=ssl.SSLContext(), **kwargs)
 
         status_code = response.getcode()
 


### PR DESCRIPTION
**Description**
Added SSL context, needed for downloading ngrok in some cases.

**Issues**
On some PCs, a SSL context when downloading ngrok, on the installation process, was needed.

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
