### PR TITLE
Use default NGROK_AUTH_TOKEN env variable

### DIFF
--- a/pyngrok/conf.py
+++ b/pyngrok/conf.py
@@ -51,7 +51,7 @@ class PyngrokConfig:
     def __init__(self,
                  ngrok_path: Optional[str] = None,
                  config_path: Optional[str] = None,
-                 auth_token: Optional[str] = None,
+                 auth_token: Optional[str] = os.environ.get("NGROK_AUTH_TOKEN"),
                  region: Optional[str] = None,
                  monitor_thread: bool = True,
                  log_event_callback: Optional[Callable[[NgrokLog], None]] = None,


### PR DESCRIPTION
**Description**
This PR modifies the `PyngrokConfig` class in `pyngrok/conf.py` to use an environment variable for the `auth_token` default value. This change is helps with ngrok now requires an AUTH_TOKEN, and without it, an error is thrown `pyngrok.exception.PyngrokNgrokError: The ngrok process errored on start: authentication failed: Usage of ngrok requires a verified account and authtoken.`.

**Issues**
- None

**Type of Change**
- [x] New feature (non-breaking change which adds functionality)

**Testing Done**
Manual testing was done to ensure that the application works as expected with the new changes.

**Checklist**
- [x] My code follows the PEP 8 style guidelines for Python
- [x] I have performed a self-review of my own code
- [x] I have commented my code in particularly hard-to-understand areas
- [ ] If applicable, I have made corresponding changes to the documentation
- [ ] I have added tests that prove my change is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings