### PR TITLE
fix building documentation out of source tree

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,8 +5,6 @@ import datetime
 import os
 import sys
 
-from pyngrok import __version__
-
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -14,6 +12,8 @@ from pyngrok import __version__
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
 sys.path.insert(0, os.path.abspath(".."))
+
+from pyngrok import __version__
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
Move importing pyngrok after altering `sys.path`.
This itrival fix allows buid documentation without have `pyngrok` installed using only source tree.

### Description
A clear and concise description of what was changed.

Fixes # (issue number)

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a schema change
- [ ] This change requires a documentation update

### Testing Done
A clear and concise description of the new tests added to validate the change as well as any manual testing done.

### Checklist
- [ ] I have added tests that prove my change works as expected, and `make test` passes with no new errors or warnings
- [x] I have run `make check` to ensure no new errors or warnings
- [ ] I have updated the docs, if applicable, and run `make docs` to ensure no new errors or warnings
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in particularly hard-to-understand areas

Without that patch documentation build fails with
```console
+ /usr/bin/sphinx-build -n -T -b man docs build/sphinx/man
Running Sphinx v7.2.6

Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/sphinx/config.py", line 358, in eval_config_file
    exec(code, namespace)  # NoQA: S102
  File "/home/tkloczko/rpmbuild/BUILD/pyngrok-7.1.5/docs/conf.py", line 8, in <module>
    from pyngrok import __version__
ModuleNotFoundError: No module named 'pyngrok'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/sphinx/cmd/build.py", line 293, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
  File "/usr/lib/python3.9/site-packages/sphinx/application.py", line 211, in __init__
    self.config = Config.read(self.confdir, confoverrides or {}, self.tags)
  File "/usr/lib/python3.9/site-packages/sphinx/config.py", line 181, in read
    namespace = eval_config_file(filename, tags)
  File "/usr/lib/python3.9/site-packages/sphinx/config.py", line 371, in eval_config_file
    raise ConfigError(msg % traceback.format_exc()) from exc
sphinx.errors.ConfigError: There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/sphinx/config.py", line 358, in eval_config_file
    exec(code, namespace)  # NoQA: S102
  File "/home/tkloczko/rpmbuild/BUILD/pyngrok-7.1.5/docs/conf.py", line 8, in <module>
    from pyngrok import __version__
ModuleNotFoundError: No module named 'pyngrok'


Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/sphinx/config.py", line 358, in eval_config_file
    exec(code, namespace)  # NoQA: S102
  File "/home/tkloczko/rpmbuild/BUILD/pyngrok-7.1.5/docs/conf.py", line 8, in <module>
    from pyngrok import __version__
ModuleNotFoundError: No module named 'pyngrok'
```
