### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,3 +1,7 @@
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 name: "Stale Check"
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/alexdlaird/pyngrok/security/code-scanning/9](https://github.com/alexdlaird/pyngrok/security/code-scanning/9)

To fix the problem, we need to add a `permissions` key specifying the minimal privileges required for `actions/stale@v9` to function correctly. Since the action will comment on, label, and close issues and pull requests, it requires `write` access to both `issues` and `pull-requests`. In addition, `contents: read` is a safe default for most cases. The `permissions` block can go at the workflow root (applies to all jobs) or at the job level. Here, adding it at the root is clear and protects all jobs by default. The change should be near the top of the workflow, after the `name:` but before `jobs:` or `on:` for best readability.

No imports or other setup is needed. Only the addition of:

```yaml
permissions:
  contents: read
  issues: write
  pull-requests: write
```
near the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
