### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   comment:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/alexdlaird/pyngrok/security/code-scanning/4](https://github.com/alexdlaird/pyngrok/security/code-scanning/4)

To fix this problem, an explicit `permissions` block should be added to the workflow to restrict the GitHub Actions token to the minimum access required for the workflow to function. In this specific case, the only necessary permission is `issues: write`, because the workflow triggers on issue label events and uses an action to comment on issues. The permissions block can be added either at the workflow root (affecting all jobs), or at the job level (inside the `comment` job). To be most clear and future-proof, the best practice is to add the `permissions` block at the job level, unless many jobs share exactly the same needs. 

**Required changes:**  
Within `.github/workflows/label-commenter.yml`, add a `permissions:` section under the `comment:` job, e.g.:  
```yaml
    permissions:
      issues: write
```
This should be directly after the job name and before `runs-on`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
