### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Validate
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/alexdlaird/pyngrok/security/code-scanning/7](https://github.com/alexdlaird/pyngrok/security/code-scanning/7)

To fix this problem, an explicit `permissions` block needs to be added such that the GITHUB_TOKEN has only the privileges required for this job. The safest minimal starting point, as suggested, is `contents: read`, unless a step requires broader permissions. Reviewing the workflow, the action steps use `actions/checkout`, `actions/setup-python`, run various test/documentation commands, and use the Codecov actions. None of these steps inherently require write permissions to the repository contents (Codecov actions only upload via api tokens/secrets). Thus, adding  
```yaml
permissions:
  contents: read
```  
at the workflow root (line 2-3) restricts the permissions for all jobs in this workflow, complying with the recommendation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
