### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Build
 
 run-name: Build ${{ github.ref_name }}
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/alexdlaird/pyngrok/security/code-scanning/6](https://github.com/alexdlaird/pyngrok/security/code-scanning/6)

To fix the problem, you should add an explicit `permissions` block so that the workflow restricts the permissions granted to GITHUB_TOKEN, following the principle of least privilege. The minimal permissions required for most build and test jobs are `contents: read`. You can add the `permissions:` key with `contents: read` at the root level of the workflow to apply this setting to all jobs. Place the permissions block after the `run-name` or `on` blocks for clarity, ideally right after the workflow name and run-name.

No new methods, imports, or definitions are required; this is a configuration change within the YAML file only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
