### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: read
+
 run-name: Release ${{ github.ref_name }}
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/alexdlaird/pyngrok/security/code-scanning/11](https://github.com/alexdlaird/pyngrok/security/code-scanning/11)

To fix the problem, you need to add a `permissions` block to the workflow file (`.github/workflows/release.yml`). This block can be placed at the top level (workflow-wide), so all jobs inherit the minimum permissions, unless they need more. By default, you should set `contents: read` as a minimal starting point. For jobs that need write permissions (e.g., those that publish artifacts or create releases), you can elevate just those jobs to `contents: write` or add specific types like `pull-requests: write` if needed.

For this particular workflow:
- Add the following block right after the workflow name and before `on:`:
  ```yaml
  permissions:
    contents: read
    # Add more as needed for jobs that require write access
  ```
- If any jobs (like `release`) require write access to releases, either elevate permissions for that job, or at the root specify additional permissions. For minimal fix, provide `contents: read` at the root; jobs needing more can later override or extend.
- No additional methods or imports required—the change is just to GitHub Actions YAML syntax.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
