### PR TITLE
Fix for `name` 400s due to `ngrok`'s new Agent

### DIFF
--- a/pyngrok/ngrok.py
+++ b/pyngrok/ngrok.py
@@ -271,6 +271,7 @@ def _interpolate_tunnel_definition(pyngrok_config: PyngrokConfig,
         tunnel_definition.update(options)
         options.clear()
         options.update(tunnel_definition)
+        name += "-agent"
 
     if "labels" in options and not pyngrok_config.api_key:
         raise PyngrokError(

--- a/tests/test_ngrok.py
+++ b/tests/test_ngrok.py
@@ -647,13 +647,13 @@ class TestNgrok(NgrokTestCase):
         ssh_tunnel = ngrok.connect(name="tcp-tunnel", pyngrok_config=pyngrok_config)
 
         # THEN
-        self.assertEqual(http_tunnel.name, "http-tunnel (http)")
+        self.assertEqual(http_tunnel.name, "http-tunnel-agent (http)")
         self.assertEqual(http_tunnel.config["addr"],
                          f"http://localhost:{config['tunnels']['http-tunnel']['addr']}")
         self.assertEqual(http_tunnel.proto, config["tunnels"]["http-tunnel"]["proto"])
         self.assertEqual(http_tunnel.public_url,
                          f"http://{config['tunnels']['http-tunnel']['subdomain']}.ngrok.io")
-        self.assertEqual(ssh_tunnel.name, "tcp-tunnel")
+        self.assertEqual(ssh_tunnel.name, "tcp-tunnel-agent")
         self.assertEqual(ssh_tunnel.config["addr"],
                          f"localhost:{config['tunnels']['tcp-tunnel']['addr']}")
         self.assertEqual(ssh_tunnel.proto, config["tunnels"]["tcp-tunnel"]["proto"])
@@ -695,14 +695,14 @@ class TestNgrok(NgrokTestCase):
         response_body = urlopen(http_tunnel.public_url).read().decode()
 
         # THEN
-        self.assertEqual(http_tunnel.name, "http-tunnel")
+        self.assertEqual(http_tunnel.name, "http-tunnel-agent")
         self.assertEqual(http_tunnel.config["addr"],
                          f"http://localhost:{config['tunnels']['http-tunnel']['addr']}")
         self.assertTrue(http_tunnel.config["addr"].startswith("http://"))
         self.assertEqual(http_tunnel.public_url,
                          f"https://{config['tunnels']['http-tunnel']['subdomain']}.ngrok.io")
         self.assertIn("Sign in - Google Accounts", response_body)
-        self.assertEqual(ssh_tunnel.name, "tcp-tunnel")
+        self.assertEqual(ssh_tunnel.name, "tcp-tunnel-agent")
         self.assertEqual(ssh_tunnel.config["addr"],
                          f"localhost:{config['tunnels']['tcp-tunnel']['addr']}")
         self.assertEqual(ssh_tunnel.proto, config["tunnels"]["tcp-tunnel"]["proto"])
@@ -736,7 +736,7 @@ class TestNgrok(NgrokTestCase):
         self.assertEqual(tls_tunnel.config["addr"],
                          f"localhost:{config['tunnels']['tls-tunnel']['addr']}")
         self.assertTrue(tls_tunnel.config["addr"], "localhost:80")
-        self.assertEqual(tls_tunnel.name, "tls-tunnel")
+        self.assertEqual(tls_tunnel.name, "tls-tunnel-agent")
         self.assertEqual(tls_tunnel.config["addr"],
                          f"localhost:{config['tunnels']['tls-tunnel']['addr']}")
         self.assertEqual(tls_tunnel.proto, config["tunnels"]["tls-tunnel"]["proto"])
@@ -766,7 +766,7 @@ class TestNgrok(NgrokTestCase):
         tunnels = ngrok.get_tunnels(pyngrok_config=pyngrok_config)
 
         # THEN
-        self.assertEqual(edge_http_tunnel.name, "edge-http-tunnel")
+        self.assertEqual(edge_http_tunnel.name, "edge-http-tunnel-agent")
         self.assertEqual(edge_http_tunnel.config["addr"],
                          f"http://localhost:{config['tunnels']['edge-http-tunnel']['addr']}")
         self.assertTrue(edge_http_tunnel.config["addr"].startswith("http://"))
@@ -774,7 +774,7 @@ class TestNgrok(NgrokTestCase):
         self.assertEqual(edge_http_tunnel.public_url,
                          "https://{domain}:443".format(domain=self.http_edge_reserved_domain))
         self.assertEqual(len(tunnels), 1)
-        self.assertEqual(tunnels[0].name, "edge-http-tunnel")
+        self.assertEqual(tunnels[0].name, "edge-http-tunnel-agent")
         self.assertEqual(tunnels[0].config["addr"],
                          f"http://localhost:{config['tunnels']['edge-http-tunnel']['addr']}")
         self.assertTrue(tunnels[0].config["addr"].startswith("http://"))
@@ -807,14 +807,14 @@ class TestNgrok(NgrokTestCase):
         tunnels = ngrok.get_tunnels(pyngrok_config=pyngrok_config)
 
         # THEN
-        self.assertEqual(edge_tcp_tunnel.name, "edge-tcp-tunnel")
+        self.assertEqual(edge_tcp_tunnel.name, "edge-tcp-tunnel-agent")
         self.assertEqual(edge_tcp_tunnel.config["addr"],
                          f"tcp://localhost:{config['tunnels']['edge-tcp-tunnel']['addr']}")
         self.assertTrue(edge_tcp_tunnel.config["addr"].startswith("tcp://"))
         self.assertEqual(edge_tcp_tunnel.proto, "tcp")
         self.assertEqual(edge_tcp_tunnel.public_url, f"tcp://{hostname}:{port}")
         self.assertEqual(len(tunnels), 1)
-        self.assertEqual(tunnels[0].name, "edge-tcp-tunnel")
+        self.assertEqual(tunnels[0].name, "edge-tcp-tunnel-agent")
         self.assertEqual(tunnels[0].config["addr"],
                          f"tcp://localhost:{config['tunnels']['edge-tcp-tunnel']['addr']}")
         self.assertTrue(tunnels[0].config["addr"].startswith("tcp://"))
@@ -845,7 +845,7 @@ class TestNgrok(NgrokTestCase):
         tunnels = ngrok.get_tunnels(pyngrok_config=pyngrok_config)
 
         # THEN
-        self.assertEqual(edge_tls_tunnel.name, "edge-tls-tunnel")
+        self.assertEqual(edge_tls_tunnel.name, "edge-tls-tunnel-agent")
         self.assertEqual(edge_tls_tunnel.config["addr"],
                          f"https://localhost:{config['tunnels']['edge-tls-tunnel']['addr']}")
         self.assertTrue(edge_tls_tunnel.config["addr"].startswith("https://"))
@@ -853,7 +853,7 @@ class TestNgrok(NgrokTestCase):
         self.assertEqual(edge_tls_tunnel.public_url,
                          "tls://{domain}:443".format(domain=self.tls_edge_reserved_domain))
         self.assertEqual(len(tunnels), 1)
-        self.assertEqual(tunnels[0].name, "edge-tls-tunnel")
+        self.assertEqual(tunnels[0].name, "edge-tls-tunnel-agent")
         self.assertEqual(tunnels[0].config["addr"],
                          f"https://localhost:{config['tunnels']['edge-tls-tunnel']['addr']}")
         self.assertTrue(tunnels[0].config["addr"].startswith("https://"))
@@ -947,6 +947,37 @@ class TestNgrok(NgrokTestCase):
         self.assertEqual(tunnels[0].public_url, "tls://pyngrok.internal")
 
     @unittest.skipIf(not os.environ.get("NGROK_AUTHTOKEN"), "NGROK_AUTHTOKEN environment variable not set")
+    def test_tunnel_definitions_pyngrok_default(self):
+        subdomain = generate_name_for_subdomain("pyngrok-temp")
+
+        # GIVEN
+        config = {
+            "tunnels": {
+                "pyngrok-default": {
+                    "proto": "http",
+                    "addr": "8080",
+                    "subdomain": subdomain
+                }
+            }
+        }
+        config_path = os.path.join(self.config_dir, "config_v3_2.yml")
+        installer.install_default_config(config_path, config, ngrok_version="v3")
+        subdomain = generate_name_for_subdomain("pyngrok-temp")
+        pyngrok_config = self.copy_with_updates(self.pyngrok_config_v3,
+                                                config_path=config_path)
+
+        # WHEN
+        ngrok_tunnel = ngrok.connect(pyngrok_config=pyngrok_config)
+
+        # THEN
+        self.assertEqual(ngrok_tunnel.name, "pyngrok-default-agent")
+        self.assertEqual(ngrok_tunnel.config["addr"],
+                         f"http://localhost:{config['tunnels']['pyngrok-default']['addr']}")
+        self.assertEqual("http", config["tunnels"]["pyngrok-default"]["proto"])
+        self.assertEqual(ngrok_tunnel.public_url,
+                         f"https://{config['tunnels']['pyngrok-default']['subdomain']}.ngrok.io")
+
+    @unittest.skipIf(not os.environ.get("NGROK_AUTHTOKEN"), "NGROK_AUTHTOKEN environment variable not set")
     def test_tunnel_definitions_pyngrok_default_with_overrides(self):
         subdomain = generate_name_for_subdomain("pyngrok-temp")
 
@@ -967,20 +998,13 @@ class TestNgrok(NgrokTestCase):
                                                 config_path=config_path)
 
         # WHEN
-        ngrok_tunnel1 = ngrok.connect(pyngrok_config=pyngrok_config)
-        ngrok_tunnel2 = ngrok.connect("5000", subdomain=subdomain, pyngrok_config=pyngrok_config)
+        ngrok_tunnel = ngrok.connect("5000", subdomain=subdomain, pyngrok_config=pyngrok_config)
 
         # THEN
-        self.assertEqual(ngrok_tunnel1.name, "pyngrok-default")
-        self.assertEqual(ngrok_tunnel1.config["addr"],
-                         f"http://localhost:{config['tunnels']['pyngrok-default']['addr']}")
+        self.assertEqual(ngrok_tunnel.name, "pyngrok-default-agent")
+        self.assertEqual(ngrok_tunnel.config["addr"], "http://localhost:5000")
         self.assertEqual("http", config["tunnels"]["pyngrok-default"]["proto"])
-        self.assertEqual(ngrok_tunnel1.public_url,
-                         f"https://{config['tunnels']['pyngrok-default']['subdomain']}.ngrok.io")
-        self.assertEqual(ngrok_tunnel2.name, "pyngrok-default")
-        self.assertEqual(ngrok_tunnel2.config["addr"], "http://localhost:5000")
-        self.assertEqual("http", config["tunnels"]["pyngrok-default"]["proto"])
-        self.assertIn(subdomain, ngrok_tunnel2.public_url)
+        self.assertIn(subdomain, ngrok_tunnel.public_url)
 
     @unittest.skipIf(not os.environ.get("NGROK_AUTHTOKEN"), "NGROK_AUTHTOKEN environment variable not set")
     def test_upgrade_ngrok_config_file_v2_to_v3(self):
@@ -1275,7 +1299,7 @@ class TestNgrok(NgrokTestCase):
                                                 api_key="api-key", )
 
         expected_options = config["tunnels"]["my-tunnel"].copy()
-        expected_options["name"] = "my-tunnel"
+        expected_options["name"] = "my-tunnel-agent"
 
         # WHEN
         ngrok.connect(name="my-tunnel", pyngrok_config=pyngrok_config)

--- a/tests/test_ngrok.py
+++ b/tests/test_ngrok.py
@@ -652,9 +652,9 @@ class TestNgrok(NgrokTestCase):
         self.assertEqual(http_tunnel.name, "http-tunnel-agent")
         self.assertEqual(http_tunnel.config["addr"],
                          f"http://localhost:{config['tunnels']['http-tunnel']['addr']}")
-        self.assertEqual(http_tunnel.proto, config["tunnels"]["http-tunnel"]["proto"])
+        self.assertEqual(http_tunnel.proto, "https")
         self.assertEqual(http_tunnel.public_url,
-                         f"http://{config['tunnels']['http-tunnel']['subdomain']}.ngrok.io")
+                         f"https://{config['tunnels']['http-tunnel']['subdomain']}.ngrok.io")
         self.assertEqual(ssh_tunnel.name, "tcp-tunnel-agent")
         self.assertEqual(ssh_tunnel.config["addr"],
                          f"localhost:{config['tunnels']['tcp-tunnel']['addr']}")


### PR DESCRIPTION
Whether they consider it a regression or not, a behavior change in the [3.29.0](https://ngrok.com/docs/agent/changelog/) agent introduces behavior which breaks use of a named tunnel definition. This PR addresses that, but before merging I'm waiting to hear back from them if this was intended and will remain, or if they will fix the regression.